### PR TITLE
Checkout/history chain

### DIFF
--- a/assets/scripts/auth/events.js
+++ b/assets/scripts/auth/events.js
@@ -21,6 +21,11 @@ const onSignUp = function (event) {
           .then(printUI.indexPrintsSuccess)
           .catch(printUI.indexPrintsFailure)
         })
+        .then(() => {
+          printAPI.showOrder()
+            .then(printUI.showOrderSuccess)
+            .catch(printUI.showOrderFailure)
+        })
         .catch(ui.signInFailure)
     })
     .catch(ui.signUpFailure)
@@ -35,6 +40,11 @@ const onSignIn = function (event) {
       printAPI.indexPrints()
       .then(printUI.indexPrintsSuccess)
       .catch(printUI.indexPrintsFailure)
+    })
+    .then(() => {
+      printAPI.showOrder()
+        .then(printUI.showOrderSuccess)
+        .catch(printUI.showOrderFailure)
     })
     .catch(ui.signInFailure)
 }

--- a/assets/scripts/printAPI/events.js
+++ b/assets/scripts/printAPI/events.js
@@ -94,6 +94,11 @@ const handleToken = function (token) {
     .then(() => {
       onRemovePrints()
     })
+    .then(() => {
+      api.showOrder()
+        .then(ui.showOrderSuccess)
+        .catch(ui.showOrderFailure)
+    })
     .catch(ui.tokenFailure)
 }
 


### PR DESCRIPTION
This chains the showOrder() method to sign in/sign up and upon successful purchase of a print. The client does not need to re-click the view purchases button to see recent purchases. That said, when attempting to remove the get requests on sign in/up, I ran into an issue with this function:

```
const isPrintAlreadyInCart = function (printArray, printId) {
  if (printArray.prints.length === 0) {
    return isInArray
  }
  let isInArray = false
  for (let i = 0; i < printArray.prints.length; i++) {
  // need to be double equal, does not work with strict equality
    if (printArray.prints[i].idNum == printId) {
      isInArray = true
      return isInArray
    }
  }
  return isInArray
}
```
I left the chaining on sign in and sign up for now and will further investigate on another branch. All user actions function as expected with this pull request.