### PR TITLE
Removes showOrder() from signin/up

### DIFF
--- a/assets/scripts/auth/events.js
+++ b/assets/scripts/auth/events.js
@@ -21,11 +21,6 @@ const onSignUp = function (event) {
           .then(printUI.indexPrintsSuccess)
           .catch(printUI.indexPrintsFailure)
         })
-        .then(() => {
-          printAPI.showOrder()
-            .then(printUI.showOrderSuccess)
-            .catch(printUI.showOrderFailure)
-        })
         .catch(ui.signInFailure)
     })
     .catch(ui.signUpFailure)
@@ -40,11 +35,6 @@ const onSignIn = function (event) {
       printAPI.indexPrints()
       .then(printUI.indexPrintsSuccess)
       .catch(printUI.indexPrintsFailure)
-    })
-    .then(() => {
-      printAPI.showOrder()
-        .then(printUI.showOrderSuccess)
-        .catch(printUI.showOrderFailure)
     })
     .catch(ui.signInFailure)
 }


### PR DESCRIPTION
It is not needed. I cannot remove index prints on sign in or up
for some reason but I think it looks great as is.