### PR TITLE
Allows "come back soon message" to display

### DIFF
--- a/assets/scripts/auth/ui.js
+++ b/assets/scripts/auth/ui.js
@@ -49,6 +49,7 @@ const changePasswordFailure = () => {
 
 const signOutSuccess = (data) => {
   $('.text-display').text('Thanks for shopping. Come back soon!')
+  $('.text-display').show()
   $('.hideBeforeLogin').hide()
   $('.sign-in-area').removeClass('hidden')
   $('#log-in').removeClass('hidden')


### PR DESCRIPTION
because of the fade out on change password, the signout display
message was not being shown. I added a .show() to the sign out message
to ensure it is visible on signout. Not a big deal but worth adding.